### PR TITLE
Fixing "Host name verification failed error"

### DIFF
--- a/NetSSL_Win/src/SecureSocketImpl.cpp
+++ b/NetSSL_Win/src/SecureSocketImpl.cpp
@@ -700,7 +700,7 @@ void SecureSocketImpl::connectSSL(bool completeHandshake)
 
 	if (_peerHostName.empty())
 	{
-		_peerHostName = _pSocket->address().host().toString();
+		_peerHostName = _pSocket->peerAddress().host().toString();
 	}
 
 	initClientContext();
@@ -1522,7 +1522,7 @@ void SecureSocketImpl::stateIllegal()
 
 void SecureSocketImpl::stateConnected()
 {
-	_peerHostName = _pSocket->address().host().toString();
+	_peerHostName = _pSocket->peerAddress().host().toString();
 	initClientContext();
 	performInitialClientHandshake();
 }


### PR DESCRIPTION
This is fixing "Host name verification failed error" that occurs with Windows SChannel. Regressing bug (pull request #1157 fixed this originally).